### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # PS4_JSC_ConcatMemcpy_POC
 
-Works on 6.0x firmware.. Patched on lower firmware
+Works on 6.0x firmware.. Exploited function does not exist on lower FW(s), meaning it does not work on them.
 
 |Firmware | Webkit Version | Vulnerable? |
 | :--- | :---: | ---: |
@@ -10,6 +10,8 @@ Works on 6.0x firmware.. Patched on lower firmware
 | 6.02 | `605.1.15` | 🗹 Yes |
 | 6.00 | `605.1.15 ` | 🗹 Yes |
 | 5.55 | `601.2 ` | 🗷 No |
+| 5.53 | `601.2 ` | 🗷 No |
+| 5.50 | `601.2 ` | 🗷 No |
 | 5.07 | `601.2 ` | 🗷 No |
 
 [Source](https://raw.githubusercontent.com/externalist/exploit_playground/master/jsc_ConcatMemcpy_infoleak/ileak.html)


### PR DESCRIPTION
"patched" is a wrong word used here, this function simply does not exist on earlier versions of WebKit, so I fixed that for you.
Also added missing 5.XX FW(s) to the list.